### PR TITLE
Update modules.config.php

### DIFF
--- a/chapter12/whatstore/config/modules.config.php
+++ b/chapter12/whatstore/config/modules.config.php
@@ -6,6 +6,7 @@
  * This should be an array of module namespaces used in the application.
  */
 return [
+    'Laminas\Mvc\Plugin\FlashMessenger',
     'Laminas\I18n',
     'Laminas\Form',
     'Laminas\Hydrator',


### PR DESCRIPTION
The plugin needs to be added to the modules,config.php. If it is not, then the Module.php file is not called. Which means the service is not registered with the plugin manager instance. Which in turn means, that you must add configuration for the plugin in a module.config.php file, which you do, but its not needed if the component is correctly installed.